### PR TITLE
Allow manual deploy run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
The main pipeline didn't run after the last merge. I'm not sure why, but this change adds the ability for us to trigger the main pipeline manually, which we have on other repos.